### PR TITLE
GNOME 3.38

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+build-dir/
+.flatpak-builder/

--- a/org.gnome.Logs.json
+++ b/org.gnome.Logs.json
@@ -1,7 +1,7 @@
 {
   "app-id": "org.gnome.Logs",
   "runtime": "org.gnome.Platform",
-  "runtime-version": "3.36",
+  "runtime-version": "3.38",
   "sdk": "org.gnome.Sdk",
   "command": "gnome-logs",
   "finish-args": [

--- a/org.gnome.Logs.json
+++ b/org.gnome.Logs.json
@@ -23,8 +23,8 @@
         {
           "type": "git",
           "url": "https://github.com/lz4/lz4",
-          "tag": "v1.9.0",
-          "commit": "131896ab9d4fc9b8c606616327ed223d5d86472b"
+          "tag": "v1.9.2",
+          "commit": "fdf2ef5809ca875c454510610764d9125ef2ebbd"
         }
       ]
     },
@@ -90,8 +90,8 @@
         {
           "type": "git",
           "url": "https://github.com/systemd/systemd.git",
-          "tag": "v242",
-          "commit": "1e5d2d656420d0e755dbcf72aeba3c3aba54e956"
+          "tag": "v246",
+          "commit": "ae366f3acbc1a45504e9875099b17a7e1a221d03"
         }
       ]
     },


### PR DESCRIPTION
- Add .gitignore
- Update runtime to GNOME 3.38
- Update systemd and lz4 dependency 