### PR TITLE
systemd: Sync manifest with upstream

### DIFF
--- a/org.gnome.Logs.json
+++ b/org.gnome.Logs.json
@@ -126,7 +126,15 @@
                 "/lib/systemd",
                 "/lib/udev",
                 "/app/share/doc",
-                "/share"
+                "/share/dbus-1",
+                "/share/doc",
+                "/share/factory",
+                "/share/glib-2.0",
+                "/share/icons",
+                "/share/man",
+                "/share/pkgconfig",
+                "/share/polkit-1",
+                "/share/runtime"
             ],
             "sources": [
                 {


### PR DESCRIPTION
Should fix: https://github.com/flathub/org.gnome.Logs/issues/10.