### PR TITLE
Use lz4 module from runtime

### DIFF
--- a/org.gnome.Logs.json
+++ b/org.gnome.Logs.json
@@ -18,23 +18,6 @@
     ],
     "modules": [
         {
-            "name": "liblz4",
-            "buildsystem": "meson",
-            "subdir": "build/meson",
-            "sources": [
-                {
-                    "type": "git",
-                    "url": "https://github.com/lz4/lz4",
-                    "tag": "v1.10.0",
-                    "commit": "ebb370ca83af193212df4dcbadcc5d87bc0de2f0",
-                    "x-checker-data": {
-                        "type": "git",
-                        "tag-pattern": "^v([\\d.]+)$"
-                    }
-                }
-            ]
-        },
-        {
             "name": "rsync",
             "config-opts": [
                 "--disable-zstd",


### PR DESCRIPTION
GNOME runtime 49 (based on the Freedesktop runtime version 25.08) appears to provide the lz4 module.

Fixes: https://github.com/flathub/org.gnome.Logs/issues/25